### PR TITLE
Fixing Bugs on Issues 6 and 11

### DIFF
--- a/updog/utils/path.py
+++ b/updog/utils/path.py
@@ -3,6 +3,8 @@ import os
 from math import log2
 from time import ctime
 
+from updog.utils.output import warn
+
 
 def is_valid_subpath(relative_directory, base_directory):
     in_question = os.path.abspath(os.path.join(base_directory, relative_directory))
@@ -31,21 +33,24 @@ def human_readable_file_size(size):
 def process_files(directory_files, base_directory):
     files = []
     for file in directory_files:
-        if file.is_dir():
-            size = '--'
-            size_sort = -1
+        if os.path.exists(file.path):
+            if file.is_dir():
+                size = '--'
+                size_sort = -1
+            else:
+                size = human_readable_file_size(file.stat().st_size)
+                size_sort = file.stat().st_size
+            files.append({
+                'name': file.name,
+                'is_dir': file.is_dir(),
+                'rel_path': get_relative_path(file.path, base_directory),
+                'size': size,
+                'size_sort': size_sort,
+                'last_modified': ctime(file.stat().st_mtime),
+                'last_modified_sort': file.stat().st_mtime
+            })
         else:
-            size = human_readable_file_size(file.stat().st_size)
-            size_sort = file.stat().st_size
-        files.append({
-            'name': file.name,
-            'is_dir': file.is_dir(),
-            'rel_path': get_relative_path(file.path, base_directory),
-            'size': size,
-            'size_sort': size_sort,
-            'last_modified': ctime(file.stat().st_mtime),
-            'last_modified_sort': file.stat().st_mtime
-        })
+            warn(f"File {file.path} does not exist!")
     return files
 
 

--- a/updog/utils/path.py
+++ b/updog/utils/path.py
@@ -19,7 +19,12 @@ def is_valid_upload_path(path, base_directory):
 
 
 def get_relative_path(file_path, base_directory):
-    return file_path.split(os.path.commonprefix([base_directory, file_path]))[1][1:]
+    # Edge case of base_directory being /
+    if base_directory == '/':
+        base_directory = ''
+    # Instead of file_path.split(os.path.commonprefix([base_directory, file_path]))[1][1:]
+    relative_path = os.path.relpath(file_path, start=base_directory)
+    return relative_path
 
 
 def human_readable_file_size(size):


### PR DESCRIPTION
The two following bugs were fixed:

## 1. [Dead Symlink Handling](https://github.com/sc0tfree/updog/issues/6)

### Description
When serving the dir `/` and trying to navigate to other folders, i.e. `/etc/`, the request made was to `/tc`.

### Problem
The function `get_relative_path` in `utils/path.py` worked fine for every served directory because the function `os.path.abspath`, used multiple times within the code, removed any ending `/` character. The problem came when the served directory was `/`. This was the only case where a folder contained a finishing slash `/` causing a bug in how the path was interpreted.

### Solution
Substitute the previous logic to get a relative path using now the `os.path.relpath()` function, and manually handling the edge case of `/` being served with a special `if` statement to convert it to the empty string `''`.

## 2. [Serving "/" leads to miss the first letter of directory](https://github.com/sc0tfree/updog/issues/11)

### Description
Web server crashes if it's asked to list a directory containing a dead symlink.

### Problem
The function `process_files` calls the function `file.is_dir()`. When the variable `file` is a dead symlink, this raises an exception which is not handled and makes Updog crash.

### Solution
Add an extra check before the line `file.is_dir()` where we validate that the file exists, using the `os.path.exists()` function.